### PR TITLE
cleanup, export mgf with feature annotation, collect grouped spectra,…

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/EfficientDataAccess.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/EfficientDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -44,8 +44,8 @@ public class EfficientDataAccess {
 
   /**
    * The intended use of this memory access is to loop over all scans in a {@link RawDataFile} and
-   * access data points via {@link ScanDataAccess#getMzValue(int)} and {@link
-   * ScanDataAccess#getIntensityValue(int)}
+   * access data points via {@link ScanDataAccess#getMzValue(int)} and
+   * {@link ScanDataAccess#getIntensityValue(int)}
    *
    * @param dataFile target data file to loop over all scans or mass lists
    * @param type     processed or raw data
@@ -55,9 +55,9 @@ public class EfficientDataAccess {
   }
 
   /**
-   * The intended use of this memory access is to loop over all selected scans in a {@link
-   * RawDataFile} and access data points via {@link ScanDataAccess#getMzValue(int)} and {@link
-   * ScanDataAccess#getIntensityValue(int)}
+   * The intended use of this memory access is to loop over all selected scans in a
+   * {@link RawDataFile} and access data points via {@link ScanDataAccess#getMzValue(int)} and
+   * {@link ScanDataAccess#getIntensityValue(int)}
    *
    * @param dataFile  target data file to loop over all scans or mass lists
    * @param type      processed or raw data
@@ -69,9 +69,9 @@ public class EfficientDataAccess {
   }
 
   /**
-   * The intended use of this memory access is to loop over all selected scans in a {@link
-   * RawDataFile} and access data points via {@link ScanDataAccess#getMzValue(int)} and {@link
-   * ScanDataAccess#getIntensityValue(int)}
+   * The intended use of this memory access is to loop over all selected scans in a
+   * {@link RawDataFile} and access data points via {@link ScanDataAccess#getMzValue(int)} and
+   * {@link ScanDataAccess#getIntensityValue(int)}
    *
    * @param dataFile target data file to loop over all scans or mass lists
    * @param type     processed or raw data
@@ -89,8 +89,7 @@ public class EfficientDataAccess {
    * @param flist target feature list. Loops through all features in all RawDataFiles
    * @param type  defines the data accession type
    */
-  public static FeatureDataAccess of(FeatureList flist,
-      FeatureDataType type) {
+  public static FeatureDataAccess of(FeatureList flist, FeatureDataType type) {
     return of(flist, type, null);
   }
 
@@ -102,8 +101,8 @@ public class EfficientDataAccess {
    * @param type     defines the data accession type
    * @param dataFile define the data file in an aligned feature list
    */
-  public static FeatureDataAccess of(FeatureList flist,
-      FeatureDataType type, RawDataFile dataFile) {
+  public static FeatureDataAccess of(FeatureList flist, FeatureDataType type,
+      RawDataFile dataFile) {
     return switch (type) {
       case ONLY_DETECTED -> new FeatureDetectedDataAccess(flist, dataFile);
       case INCLUDE_ZEROS -> new FeatureFullDataAccess(flist, dataFile);
@@ -120,11 +119,11 @@ public class EfficientDataAccess {
    * less noisy mobilograms.
    *
    * @param dataFile The {@link IMSRawDataFile}.
-   * @param binWidth The bin width (absolute, depends on the {@link io.github.mzmine.datamodel.MobilityType}.
+   * @param binWidth The bin width (absolute, depends on the
+   *                 {@link io.github.mzmine.datamodel.MobilityType}.
    * @return
    */
-  public static BinningMobilogramDataAccess of(final IMSRawDataFile dataFile,
-      final int binWidth) {
+  public static BinningMobilogramDataAccess of(final IMSRawDataFile dataFile, final int binWidth) {
     return new BinningMobilogramDataAccess(dataFile, binWidth);
   }
 
@@ -137,34 +136,50 @@ public class EfficientDataAccess {
    * Different types to handle feature data: {@link #ONLY_DETECTED}: Use only detected data points,
    * currently assigned to the feature. Features might include leading and/or trailing zeros
    * depending on the state of processing. Leading and trailing zeros are added during chromatogram
-   * detection, bit might be removed during feature resolving or other processing steps.; {@link
-   * #INCLUDE_ZEROS}: Fill all missing data points in the chromatogram with zeros;
+   * detection, bit might be removed during feature resolving or other processing steps.;
+   * {@link #INCLUDE_ZEROS}: Fill all missing data points in the chromatogram with zeros;
    */
   public enum FeatureDataType {
     ONLY_DETECTED, INCLUDE_ZEROS
   }
 
   /**
-   * Different types to handle Scan data: {@link #RAW}: Use raw data as imported; {@link #MASS_LIST}:
-   * Use processed centroid data ({@link MassList}
+   * Different types to handle Scan data: {@link #RAW}: Use raw data as imported;
+   * {@link #MASS_LIST}: Use processed centroid data ({@link MassList}
    */
   public enum ScanDataType {
-    RAW, MASS_LIST
+    RAW, MASS_LIST;
+
+    @Override
+    public String toString() {
+      return switch (this) {
+        case RAW -> "Raw";
+        case MASS_LIST -> "Processed";
+      };
+    }
   }
 
   /**
-   * Different types to handle mobility scan data: {@link #RAW}: Use raw data as imported; {@link
-   * #MASS_LIST}: Use processed centroid data ({@link MassList}
+   * Different types to handle mobility scan data: {@link #RAW}: Use raw data as imported;
+   * {@link #MASS_LIST}: Use processed centroid data ({@link MassList}
    */
   public enum MobilityScanDataType {
     // basically just a copy of ScanDataType, but useful to distinguish the factory methods
-    RAW, MASS_LIST
+    RAW, MASS_LIST;
+
+    @Override
+    public String toString() {
+      return switch (this) {
+        case RAW -> "Raw";
+        case MASS_LIST -> "Processed";
+      };
+    }
   }
 
   /**
    * {@link #ONLY_DETECTED} will only access data points stored in the mobilograms, which may or may
-   * not contain leading and trailing zeros depending on the state of processing. {@link
-   * #INCLUDE_ZEROS}: fill all missing data points in frame's mobility scans with 0 for the
+   * not contain leading and trailing zeros depending on the state of processing.
+   * {@link #INCLUDE_ZEROS}: fill all missing data points in frame's mobility scans with 0 for the
    * respective mobilogram.
    */
   public enum MobilogramAccessType {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/process_fragmentsanalysis/DataHistogramBinner.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/process_fragmentsanalysis/DataHistogramBinner.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2004-2024 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.dataprocessing.process_fragmentsanalysis;
+
+/**
+ * Bins data into an existing array
+ */
+public class DataHistogramBinner {
+
+  private final int[] data;
+  private final double binWidth;
+  private final double minValue;
+  private final double maxValueExclusive;
+  private long numberOfDataPoints = 0;
+
+  public DataHistogramBinner(final int numberOfBins, final double minValue,
+      final double maxValueExclusive) {
+    this((maxValueExclusive - minValue) / numberOfBins, minValue, maxValueExclusive);
+  }
+
+  public DataHistogramBinner(final double binWidth, final double minValue,
+      final double maxValueExclusive) {
+    double width = maxValueExclusive - minValue;
+    this.data = new int[(int) Math.ceil(width / binWidth)];
+    this.binWidth = binWidth;
+    this.minValue = minValue;
+    this.maxValueExclusive = maxValueExclusive;
+  }
+
+  public boolean addValue(final double value) {
+    if (value < minValue || value >= maxValueExclusive) {
+      return false;
+    }
+
+    int bin = (int) Math.floor((value - minValue) / binWidth);
+    data[bin]++;
+    numberOfDataPoints++;
+    return true;
+  }
+
+  /**
+   * @return -1 for out of binning data range, otherwise the frequency of this value
+   */
+  public int getBinFrequency(final double value) {
+    if (value < minValue || value >= maxValueExclusive) {
+      return -1;
+    }
+
+    int bin = (int) Math.floor((value - minValue) / binWidth);
+    return data[bin];
+  }
+
+  public int getNumBins() {
+    return data.length;
+  }
+
+  public long getNumberOfDataPoints() {
+    return numberOfDataPoints;
+  }
+
+  public int[] getHistogram() {
+    return data;
+  }
+
+  public double getMinValue() {
+    return minValue;
+  }
+
+  public double getMaxValueExclusive() {
+    return maxValueExclusive;
+  }
+
+  public double getBinWidth() {
+    return binWidth;
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/process_fragmentsanalysis/FragmentsAnalysisParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/process_fragmentsanalysis/FragmentsAnalysisParameters.java
@@ -25,11 +25,13 @@
 
 package io.github.mzmine.modules.dataprocessing.process_fragmentsanalysis;
 
+import io.github.mzmine.datamodel.data_access.EfficientDataAccess.ScanDataType;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.ComboParameter;
 import io.github.mzmine.parameters.parametertypes.filenames.FileNameSuffixExportParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
-
-import static io.github.mzmine.modules.io.projectsave.ProjectSaveAsParameters.extensions;
+import java.util.List;
+import javafx.stage.FileChooser.ExtensionFilter;
 
 /**
  * Define any parameters here (see io.github.mzmine.parameters for parameter types) static is needed
@@ -39,20 +41,30 @@ import static io.github.mzmine.modules.io.projectsave.ProjectSaveAsParameters.ex
  */
 public class FragmentsAnalysisParameters extends SimpleParameterSet {
 
-    public static final FeatureListsParameter featureLists = new FeatureListsParameter();
+  public static final FeatureListsParameter featureLists = new FeatureListsParameter();
 
-    // those are just example parameters and should be exchanged
-    public static final FileNameSuffixExportParameter outFile = new FileNameSuffixExportParameter(
-            "Filename", "Name of the output MGF file. "
-            + "Use pattern \"{}\" in the file name to substitute with feature list name. "
-            + "(i.e. \"blah{}blah.mgf\" would become \"blahSourceFeatureListNameblah.mgf\"). "
-            + "If the file already exists, it will be overwritten.", extensions, "fragmentsanalysis");
+  public static final ComboParameter<ScanDataType> scanDataType = new ComboParameter<>(
+      "MS data selection",
+      "Show either raw data or filtered centroid data (after mass detection and other filters).\n"
+      + "RAW on profile mode spectra may result in unwanted results, apply mass detection and choose centroid instead. ",
+      ScanDataType.values(), ScanDataType.MASS_LIST);
 
-    public FragmentsAnalysisParameters() {
-        /*
-         * The order of the parameters is used to construct the parameter dialog automatically
-         */
-        super(featureLists, outFile);
-    }
+  private static final List<ExtensionFilter> extensions = List.of( //
+      new ExtensionFilter("mgf format that contains MS1 and MS2 data", "*.mgf")); //
+
+  // those are just example parameters and should be exchanged
+  public static final FileNameSuffixExportParameter outFile = new FileNameSuffixExportParameter(
+      "Filename", "Name of the output MGF file. "
+                  + "Use pattern \"{}\" in the file name to substitute with feature list name. "
+                  + "(i.e. \"blah{}blah.mgf\" would become \"blahSourceFeatureListNameblah.mgf\"). "
+                  + "If the file already exists, it will be overwritten.", extensions,
+      "fragments_analysis");
+
+  public FragmentsAnalysisParameters() {
+    /*
+     * The order of the parameters is used to construct the parameter dialog automatically
+     */
+    super(featureLists, scanDataType, outFile);
+  }
 
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/process_fragmentsanalysis/FragmentsAnalysisTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/process_fragmentsanalysis/FragmentsAnalysisTask.java
@@ -25,33 +25,39 @@
 
 package io.github.mzmine.modules.dataprocessing.process_fragmentsanalysis;
 
+import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.data_access.EfficientDataAccess.ScanDataType;
+import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.compoundannotations.FeatureAnnotation;
 import io.github.mzmine.modules.MZmineModule;
 import io.github.mzmine.modules.io.spectraldbsubmit.formats.MGFEntryGenerator;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractFeatureListTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
+import io.github.mzmine.util.annotations.CompoundAnnotationUtils;
 import io.github.mzmine.util.scans.ScanUtils;
+import io.github.mzmine.util.spectraldb.entry.DBEntryField;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntry;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static java.util.Objects.requireNonNullElse;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * The task will be scheduled by the TaskController. Progress is calculated from the
@@ -59,112 +65,192 @@ import static java.util.Objects.requireNonNullElse;
  */
 class FragmentsAnalysisTask extends AbstractFeatureListTask {
 
-    private static final Logger logger = Logger.getLogger(FragmentsAnalysisTask.class.getName());
+  private static final Logger logger = Logger.getLogger(FragmentsAnalysisTask.class.getName());
 
-    private final List<FeatureList> featureLists;
-    private final File outFile;
+  private final List<FeatureList> featureLists;
+  private final File outFile;
+  private final boolean useMassList;
 
-    /**
-     * Constructor is used to extract all parameters
-     *
-     * @param featureLists data source is featureLists
-     * @param parameters   user parameters
-     */
-    public FragmentsAnalysisTask(MZmineProject project, List<FeatureList> featureLists, ParameterSet parameters,
-                                 @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate,
-                                 @NotNull Class<? extends MZmineModule> moduleClass) {
-        super(storage, moduleCallDate, parameters, moduleClass);
-        this.featureLists = featureLists;
-        // important to track progress with totalItems and finishedItems
-        totalItems = featureLists.stream().mapToInt(FeatureList::getNumberOfRows).sum();
-        // Get parameter values for easier use
-        outFile = parameters.getValue(FragmentsAnalysisParameters.outFile);
-        // TODO
-        // tolerance = ...
-    }
+  /**
+   * Constructor is used to extract all parameters
+   *
+   * @param featureLists data source is featureLists
+   * @param parameters   user parameters
+   */
+  public FragmentsAnalysisTask(MZmineProject project, List<FeatureList> featureLists,
+      ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate,
+      @NotNull Class<? extends MZmineModule> moduleClass) {
+    super(storage, moduleCallDate, parameters, moduleClass);
+    this.featureLists = featureLists;
+    // important to track progress with totalItems and finishedItems
+    totalItems = featureLists.stream().mapToInt(FeatureList::getNumberOfRows).sum();
+    // Get parameter values for easier use
+    outFile = parameters.getValue(FragmentsAnalysisParameters.outFile);
+    var scanDataType = parameters.getValue(FragmentsAnalysisParameters.scanDataType);
+    useMassList = scanDataType == ScanDataType.MASS_LIST;
+    // TODO
+    // tolerance = ...
+  }
 
-    @Override
-    protected void process() {
-        // Open file
-        try (BufferedWriter writer = Files.newBufferedWriter(outFile.toPath(),
-                StandardCharsets.UTF_8)) {
-            logger.fine(() -> String.format("Exporting GDebunk mgf for feature list: to file %s",
-                    outFile.getAbsolutePath()));
-            for (FeatureList featureList : featureLists) {
-                for (var row : featureList.getRows()) {
-                    processRow(writer, row);
-                }
-            }
-        } catch (IOException e) {
-            setStatus(TaskStatus.ERROR);
-            setErrorMessage("Could not open file " + outFile + " for writing.");
-            logger.log(Level.WARNING, String.format(
-                    "Error writing GDebunk mgf format to file: %s. Message: %s",
-                    outFile.getAbsolutePath(), e.getMessage()), e);
+  @Override
+  protected void process() {
+    // write all spectra to mgf and also put them into
+    List<GroupedFragmentScans> groupedScans = collectAndWriteSpectraToMgf();
+    logger.info("mgf export finished - now starting to analyze the grouped scans");
+
+    // TODO find signals that are common in all MS1 scans
+
+    // flatMap is used to unwrap a List into its individual elements in a stream
+    groupedScans.stream().map(GroupedFragmentScans::ms1Scans).flatMap(Collection::stream)
+        .forEach(ms1 -> {
+          // this streams through all MS1 scans in all groupings... just in case you want to create a histogram or similar things
+          // for example
+        });
+
+    // this could be used to bin the MS1 signal frequency in mz range x-z
+    var ms1MzFrequency = new DataHistogramBinner(0.001, 25, 2000);
+    groupedScans.stream().map(GroupedFragmentScans::ms1Scans).flatMap(Collection::stream)
+        .forEach(ms1 -> {
+          DataPoint[] data = ScanUtils.extractDataPoints(ms1, useMassList);
+          for (DataPoint dp : data) {
+            ms1MzFrequency.addValue(dp.getMZ());
+          }
+        });
+
+    int frequencyOfMz200 = ms1MzFrequency.getBinFrequency(200);
+
+    // TODO count signals in MS1 scans that are filtered out due to
+    //  1. common contamination
+    //  2. in source fragment found in corresponding MS2
+
+  }
+
+  private List<GroupedFragmentScans> collectAndWriteSpectraToMgf() {
+    logger.info("mgf export of grouped scans started");
+
+    List<GroupedFragmentScans> groupingResults = new ArrayList<>();
+    // Open file
+    try (BufferedWriter writer = Files.newBufferedWriter(outFile.toPath(),
+        StandardCharsets.UTF_8)) {
+      logger.fine(() -> String.format("Exporting GDebunk mgf for feature list: to file %s",
+          outFile.getAbsolutePath()));
+      for (FeatureList featureList : featureLists) {
+        for (var row : featureList.getRows()) {
+          GroupedFragmentScans result = processRow(writer, row);
+          if (!result.ms2Scans().isEmpty()) {
+            groupingResults.add(result);
+          }
         }
+      }
+    } catch (IOException e) {
+      setStatus(TaskStatus.ERROR);
+      setErrorMessage("Could not open file " + outFile + " for writing.");
+      logger.log(Level.WARNING,
+          String.format("Error writing GDebunk mgf format to file: %s. Message: %s",
+              outFile.getAbsolutePath(), e.getMessage()), e);
+      // on error return empty list
+      return List.of();
     }
+    return groupingResults;
+  }
 
-    private void processRow(BufferedWriter writer, FeatureListRow row) throws NullPointerException, IOException {
+  private GroupedFragmentScans processRow(BufferedWriter writer, FeatureListRow row)
+      throws IOException {
+    // collect all MS1 and MS2 for this row
+    List<Scan> ms1Scans = new ArrayList<>();
+    List<Scan> ms2Scans = new ArrayList<>();
 
-        Scan bestMs1 = row.getBestFeature().getRepresentativeScan();
-        // TODO Don't know why but this is failing looks like it fails when NULL?
-        // int scanNumberBestMs1 = bestMs1.getScanNumber();
-        // We can do it only on this one as it will remain the same
-        // String fileUSI = Path.of(requireNonNullElse(bestMs1.getDataFile().getAbsolutePath(),bestMs1.getDataFile().getName())).getFileName().toString();
-        // String fileUSIBestMs1 = fileUSI + ":" + scanNumberBestMs1;
-        for (Scan ms2 : row.getAllFragmentScans()) {
-            // int scanNumberMs2 = ms2.getScanNumber();
-            // String fileUSIMs2 = fileUSI + ":" + scanNumberMs2;
-            Scan previousMs1 = ScanUtils.findPrecursorScan(ms2);
-            // int scanNumberPreviousMs1 = previousMs1.getScanNumber();
-            // String fileUSIPreviousMs1 = fileUSI + ":" + scanNumberPreviousMs1;
-            Scan nextMs1 = ScanUtils.findSucceedingPrecursorScan(ms2);
-            // int scanNumberNextMs1 = previousMs1.getScanNumber();
-            // String fileUSINextMs1 = fileUSI + ":" + scanNumberNextMs1;
-            // exportScan(writer, row, ms2, fileUSIMs2);
-            // exportScan(writer, row, previousMs1, fileUSIPreviousMs1);
-            // exportScan(writer, row, nextMs1, fileUSINextMs1);
-            exportScan(writer, row, ms2);
-            exportScan(writer, row, previousMs1);
-            exportScan(writer, row, nextMs1);
+    for (final ModularFeature feature : row.getFeatures()) {
+      try {
+        List<Scan> exportedScans = processFeature(writer, row, feature);
+        for (Scan scan : exportedScans) {
+          if (scan.getMSLevel() == 1) {
+            ms1Scans.add(scan);
+          }
+          if (scan.getMSLevel() == 2) {
+            ms2Scans.add(scan);
+          }
         }
-        // exportScan(writer, row, bestMs1, fileUSIBestMs1);
-        exportScan(writer, row, bestMs1);
+      } catch (Exception ex) {
+        logger.log(Level.WARNING, ex.getMessage(), ex);
+      }
+    }
+    return new GroupedFragmentScans(row, ms1Scans, ms2Scans);
+  }
 
-// TODO Count the maximum number of common fragments between MS1 and MS2 in MS2
-// TODO Count the maximum number of common fragments between MS1 and MS2 in MS1
-//        int maxCommonFragmentsInMs2 = row.getAllFragmentScans().stream()
-//                .mapToInt(ms2 -> countCommonFragments(bestMs1, ms2, tolerance))
-//                .max().orElse(0);
-//        int maxCommonFragmentsInMs1 = row.getAllFragmentScans().stream()
-//                .mapToInt(ms2 -> countCommonFragments(ms2, bestMs1, tolerance))
-//                .max().orElse(0);
-//        row.set(SomeTypeForMaxCommonFragmentsInMs2, maxCommonFragmentsInMs2);
-//        row.set(SomeTypeForMaxCommonFragmentsInMs1, maxCommonFragmentsInMs1);
+  /**
+   * For each feature (individual sample)
+   *
+   * @return all exported scans
+   */
+  private List<Scan> processFeature(final BufferedWriter writer, final FeatureListRow row,
+      final Feature feature) throws IOException {
+    // skip if there are no MS2
+    List<Scan> fragmentScans = feature.getAllMS2FragmentScans();
+    if (fragmentScans.isEmpty()) {
+      return List.of(); // return empty list
     }
 
-    private void exportScan(
-            BufferedWriter writer,
-            FeatureListRow row,
-            Scan scan
-            // String name
-    ) throws IOException {
-        SpectralLibraryEntry entry = SpectralLibraryEntry.create(null, row.getAverageMZ(), ScanUtils.extractDataPoints(scan, true));
-        // entry.putIfNotNull(DBEntryField.ENTRY_ID, name);
-        final String mgfEntry = MGFEntryGenerator.createMGFEntry(entry);
-        writer.write(mgfEntry);
-        writer.newLine();
+    RawDataFile raw = feature.getRawDataFile();
+    String rawFileName = raw.getFileName();
+
+    // collect all scans to export
+    List<Scan> scansToExport = new ArrayList<>();
+
+    Scan bestMs1 = feature.getRepresentativeScan();
+    scansToExport.add(bestMs1);
+
+    for (Scan ms2 : fragmentScans) {
+      if (ms2.getMSLevel() != 2) {
+        continue; // skip MSn
+      }
+      scansToExport.add(ms2);
+
+      Scan previousScan = ScanUtils.findPrecursorScan(ms2);
+      if (previousScan != null) {
+        scansToExport.add(previousScan);
+      }
+      Scan nextScan = ScanUtils.findSucceedingPrecursorScan(ms2);
+      if (nextScan != null) {
+        scansToExport.add(nextScan);
+      }
     }
 
-    @Override
-    public String getTaskDescription() {
-        return STR."Fragments analysis task runs on \{featureLists}";
+    for (final Scan scan : scansToExport) {
+      exportScanToMgf(writer, row, rawFileName, scan);
     }
 
-    @Override
-    protected @NotNull List<FeatureList> getProcessedFeatureLists() {
-        return featureLists;
-    }
+    return scansToExport;
+  }
+
+  private void exportScanToMgf(BufferedWriter writer, FeatureListRow row, final String rawFileName,
+      Scan scan) throws IOException {
+    String id = String.format("%s_id%d", rawFileName, row.getID());
+    String usi = String.format("%s:%d", rawFileName, scan.getScanNumber());
+
+    FeatureAnnotation annotation = CompoundAnnotationUtils.streamFeatureAnnotations(row).findFirst()
+        .orElse(null);
+    DataPoint[] data = ScanUtils.extractDataPoints(scan, useMassList);
+    // create entry
+    var entry = SpectralLibraryEntry.create(row, null, scan, annotation, data);
+    // add additional information
+    entry.putIfNotNull(DBEntryField.ENTRY_ID, id);
+    entry.putIfNotNull(DBEntryField.USI, usi);
+    // export
+    final String mgfEntry = MGFEntryGenerator.createMGFEntry(entry);
+    writer.write(mgfEntry);
+    writer.newLine();
+  }
+
+  @Override
+  public String getTaskDescription() {
+    return STR."Fragments analysis task runs on \{featureLists}";
+  }
+
+  @Override
+  protected @NotNull List<FeatureList> getProcessedFeatureLists() {
+    return featureLists;
+  }
 
 // TODO
 //    private int countCommonFragments(Scan ms1, Scan ms2, double tolerance) {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/process_fragmentsanalysis/FragmentsAnalysisTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/process_fragmentsanalysis/FragmentsAnalysisTask.java
@@ -56,6 +56,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -101,21 +102,19 @@ class FragmentsAnalysisTask extends AbstractFeatureListTask {
     // TODO find signals that are common in all MS1 scans
 
     // flatMap is used to unwrap a List into its individual elements in a stream
-    groupedScans.stream().map(GroupedFragmentScans::ms1Scans).flatMap(Collection::stream)
-        .forEach(ms1 -> {
-          // this streams through all MS1 scans in all groupings... just in case you want to create a histogram or similar things
-          // for example
-        });
+    streamMs1Scans(groupedScans).forEach(ms1 -> {
+      // this streams through all MS1 scans in all groupings... just in case you want to create a histogram or similar things
+      // for example
+    });
 
     // this could be used to bin the MS1 signal frequency in mz range x-z
     var ms1MzFrequency = new DataHistogramBinner(0.001, 25, 2000);
-    groupedScans.stream().map(GroupedFragmentScans::ms1Scans).flatMap(Collection::stream)
-        .forEach(ms1 -> {
-          DataPoint[] data = ScanUtils.extractDataPoints(ms1, useMassList);
-          for (DataPoint dp : data) {
-            ms1MzFrequency.addValue(dp.getMZ());
-          }
-        });
+    streamMs1Scans(groupedScans).forEach(ms1 -> {
+      DataPoint[] data = ScanUtils.extractDataPoints(ms1, useMassList);
+      for (DataPoint dp : data) {
+        ms1MzFrequency.addValue(dp.getMZ());
+      }
+    });
 
     int frequencyOfMz200 = ms1MzFrequency.getBinFrequency(200);
 
@@ -123,6 +122,11 @@ class FragmentsAnalysisTask extends AbstractFeatureListTask {
     //  1. common contamination
     //  2. in source fragment found in corresponding MS2
 
+  }
+
+  private static @NotNull Stream<Scan> streamMs1Scans(
+      final List<GroupedFragmentScans> groupedScans) {
+    return groupedScans.stream().map(GroupedFragmentScans::ms1Scans).flatMap(Collection::stream);
   }
 
   private List<GroupedFragmentScans> collectAndWriteSpectraToMgf() {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/process_fragmentsanalysis/GroupedFragmentScans.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/process_fragmentsanalysis/GroupedFragmentScans.java
@@ -25,32 +25,8 @@
 
 package io.github.mzmine.modules.dataprocessing.process_fragmentsanalysis;
 
-import io.github.mzmine.datamodel.MZmineProject;
-import io.github.mzmine.datamodel.features.FeatureList;
-import io.github.mzmine.modules.MZmineModuleCategory;
-import io.github.mzmine.modules.impl.TaskPerFeatureListModule;
-import io.github.mzmine.parameters.ParameterSet;
-import io.github.mzmine.taskcontrol.Task;
-import io.github.mzmine.util.MemoryMapStorage;
-import java.time.Instant;
-import java.util.List;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-public class FragmentsAnalysisModule extends TaskPerFeatureListModule {
-
-  public FragmentsAnalysisModule() {
-    super("Fragments analysis", FragmentsAnalysisParameters.class,
-        MZmineModuleCategory.FEATURELISTEXPORT, false,
-        "This is a description of the amazing quest we have...");
-  }
-
-  @Override
-  public @NotNull Task createTask(final @NotNull MZmineProject project,
-      final @NotNull ParameterSet parameters, final @NotNull Instant moduleCallDate,
-      final @Nullable MemoryMapStorage storage, final @NotNull FeatureList featureList) {
-    return new FragmentsAnalysisTask(project, List.of(featureList), parameters, storage,
-        moduleCallDate, this.getClass());
-  }
+public record GroupedFragmentScans(io.github.mzmine.datamodel.features.FeatureListRow row,
+                                   java.util.List<io.github.mzmine.datamodel.Scan> ms1Scans,
+                                   java.util.List<io.github.mzmine.datamodel.Scan> ms2Scans) {
 
 }


### PR DESCRIPTION
- fixed FileNameParameter extensions
- added scanDataType parameter so that user can select RAW or Processed spectra
- now exporting MS2 and MS1 scans per Feature and not directly for FeatureListRow. This made it a bit simpler and you dont rely on row.getBestFeature but have the feature for the correct sample directly.
- add the FeatureAnnotation like spectral library match or compound annotation to the mgf export so that structures etc are exported
- added USI and spectrum ID
- collectAndWriteSpectraToMgf() method now writes the mgf and collects all the grouped MS1 - MS2 scans so that they can be analyzed later. See process method
- added some examples in the process method to show how to access the ms1 scans and ms2 scans. They are still connected to their rows but you can stream and then flatmap all ms1 scans into a single stream